### PR TITLE
Add mod-calendar and mod-vendor deployment descriptor templates.

### DIFF
--- a/deployment-descriptor-templates/mod-calendar.json
+++ b/deployment-descriptor-templates/mod-calendar.json
@@ -1,0 +1,10 @@
+{
+  "srvcId" : "mod-calendar",
+  "nodeId" : "10.0.2.15",
+  "descriptor" : {
+    "dockerImage" : "folioci/mod-calendar:latest",
+    "dockerArgs" : {
+      "HostConfig" : { "PortBindings": { "8081/tcp": [{ "HostPort": "%p" }] } }
+    }
+  }
+}

--- a/deployment-descriptor-templates/mod-vendors.json
+++ b/deployment-descriptor-templates/mod-vendors.json
@@ -1,0 +1,10 @@
+{
+  "srvcId" : "mod-vendors",
+  "nodeId" : "10.0.2.15",
+  "descriptor" : {
+    "dockerImage" : "folioci/mod-vendors:latest",
+    "dockerArgs" : {
+      "HostConfig" : { "PortBindings": { "8081/tcp": [{ "HostPort": "%p" }] } }
+    }
+  }
+}

--- a/gen-module-list.pl
+++ b/gen-module-list.pl
@@ -3,6 +3,8 @@ use warnings;
 use JSON;
 
 my @extra_modules = ('mod-codex-inventory','mod-codex-ekb');
+# Some modules don't have mod descriptors in the central repo
+my @exclude_modules = ('folio-testing-platform','stripes-smart-components','react-big-calendar','react-githubish-mentions','react-intl-safe-html');
 my $input_dir = $ARGV[0];
 die "Directory $input_dir not readable\n" unless (-r $input_dir && -d $input_dir);
 opendir(INPUTDIR,$input_dir) or die "Can't open input directory $input_dir: $!\n";
@@ -10,8 +12,11 @@ my @mod_descrs = grep { /^(?!\.).+/ && -f "$input_dir/$_" } readdir(INPUTDIR);
 closedir(INPUTDIR);
 my @enable;
 foreach my $i (@mod_descrs) {
-  # Actually no mod descriptor in repo for stripes-smart-components
-  if ($i !~ /stripes-smart-components/) {
+  my $exclude;
+  foreach my $j (@exclude_modules) {
+    $exclude = 1 if $i =~ /$j/;
+  }
+  unless ($exclude) {
     open(MODDESCR, "<:encoding(UTF-8)", "$input_dir/$i")
       or warn("Can't open $input_dir/$i: $!\n");
     local $/= undef;


### PR DESCRIPTION
Also tweak gen-module-list.pl to exclude frontend modules that don't have module descriptors in the central repository.