### PR TITLE
Update Okapi package version.

### DIFF
--- a/single-server.md
+++ b/single-server.md
@@ -149,7 +149,7 @@ CREATE DATABASE folio WITH OWNER folio;
 wget --quiet -O - https://repository.folio.org/packages/debian/folio-apt-archive-key.asc | sudo apt-key add -
 sudo add-apt-repository "deb https://repository.folio.org/packages/ubuntu xenial/"
 sudo apt-get update
-sudo apt-get -y install okapi=2.17.4-1
+sudo apt-get -y install okapi=2.17.4-2
 ```
 
 ### Sidebar: Okapi releases


### PR DESCRIPTION
Package version 2.17.4-2 adds startup order so Okapi doesn't start before Docker. Towards FOLIO-1542.