### PR TITLE
Use download.docker.com as APT docker repository

### DIFF
--- a/runbooks/single-server/README.md
+++ b/runbooks/single-server/README.md
@@ -99,10 +99,11 @@ sudo apt-get -y install postgresql-10 postgresql-client-10 postgresql-contrib-10
 5. Import the Docker signing key, add the Docker apt repository, install the Docker engine
 
 ```
-wget --quiet -O - https://apt.dockerproject.org/gpg | sudo apt-key add -
-sudo add-apt-repository "deb https://apt.dockerproject.org/repo ubuntu-xenial main"
+sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get update
-sudo apt-get -y install docker-engine
+sudo apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
 6. Configure Docker engine to listen on network socket

--- a/runbooks/single-server/README.md
+++ b/runbooks/single-server/README.md
@@ -99,11 +99,11 @@ sudo apt-get -y install postgresql-10 postgresql-client-10 postgresql-contrib-10
 5. Import the Docker signing key, add the Docker apt repository, install the Docker engine
 
 ```
-sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get -y install apt-transport-https ca-certificates gnupg-agent software-properties-common
+wget --quiet -O - https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io
 ```
 
 6. Configure Docker engine to listen on network socket


### PR DESCRIPTION
The procedure to install the docker engine as described in the README of single-server installation does not work anymore. The APT repository https://apt.dockerproject.org/gpg has been shut down (officially it will be shut down by March 31, 2020).
I replaced the installation steps as described in the official docker manual https://docs.docker.com/install/linux/docker-ce/ubuntu/ for docker-ce installation in Ubuntu.
If have tested these steps on my Ubuntu 16.04.6 LTS server.