### PR TITLE
FOLIO-3444: alpine:3.12.9 for TAMU/okapi/Dockerfile

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone  -b "v4.5.2" --recursive https://github.com/folio-org/okapi.git
 RUN cd okapi && mvn clean install -DskipTests
 
 #OpenJDK Alpine
-FROM alpine:3.12.0
+FROM alpine:3.12.9
 
 #Okapi Prerequisites
 RUN apk add --no-cache curl openjdk11


### PR DESCRIPTION
alpine:3.12.0 is used to run Okapi in alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile

Upgrading to alpine:3.12.9 fixes multiple security issues: https://snyk.io/test/docker/alpine%3A3.12.0