### PR TITLE
FOLIO-3561: apk/apt upgrade fixing vulnerabilities

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/bootstrap-superuser/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/bootstrap-superuser/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.15.0
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache make curl perl perl-app-cpanminus perl-json perl-libwww
+RUN apk upgrade \
+ && apk add \
+      make curl perl perl-app-cpanminus perl-json perl-libwww \
+ && rm -rf /var/cache/apk/*
 RUN cpanm UUID::Tiny
 
 #Create working directory

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-deploy-pubsub/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-deploy-pubsub/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.11
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache curl perl perl-app-cpanminus perl-json perl-libwww python py-pip
+RUN apk upgrade \
+ && apk add \
+      curl perl perl-app-cpanminus perl-json perl-libwww python py-pip \
+ && rm -rf /var/cache/apk/*
 RUN pip install --upgrade pip
 RUN pip install requests
 

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-deploy/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-deploy/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.11
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache curl perl perl-app-cpanminus perl-json perl-libwww python py-pip
+RUN apk upgrade \
+ && apk add \
+      curl perl perl-app-cpanminus perl-json perl-libwww python py-pip \
+ && rm -rf /var/cache/apk/*
 RUN pip install --upgrade pip
 RUN pip install requests
 

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-email/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-email/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.15.0
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache curl
+RUN apk upgrade \
+ && apk add \
+      curl \
+ && rm -rf /var/cache/apk/*
 
 #Create working directory
 RUN mkdir -p /usr/local/bin/folio

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-tenant/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-tenant/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.15.0
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache curl
+RUN apk upgrade \
+ && apk add \
+      curl \
+ && rm -rf /var/cache/apk/*
 
 #Create working directory
 RUN mkdir -p /usr/local/bin/folio

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/delete-deploy/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/delete-deploy/Dockerfile
@@ -1,7 +1,12 @@
 FROM alpine:3.15.0
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
 RUN apk add --no-cache curl
+RUN apk upgrade \
+ && apk add \
+      curl \
+ && rm -rf /var/cache/apk/*
 
 #Create folders in container
 RUN mkdir -p /usr/local/bin/folio/disable

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/secure-okapi/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/secure-okapi/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.15.0
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites
-RUN apk add --no-cache curl
+RUN apk upgrade \
+ && apk add \
+      curl \
+ && rm -rf /var/cache/apk/*
 
 #Create working directory
 RUN mkdir -p /usr/local/bin/folio/install

--- a/alternative-install/kubernetes-rancher/TAMU/ldp-derived-tables/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/ldp-derived-tables/Dockerfile
@@ -1,7 +1,8 @@
 FROM debian:buster-slim
 
+#Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #LDP Derived Tables Prerequisites
-RUN apt update -y && apt install -y postgresql-client libcurl4-openssl-dev perl libdbi-perl libdbd-pg-perl
+RUN apt update -y && apt upgrade -y && apt install -y postgresql-client libcurl4-openssl-dev perl libdbi-perl libdbd-pg-perl
 
 #Create folders in container
 RUN mkdir -p /usr/local/bin/ldp/sql/derived_tables

--- a/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
@@ -10,10 +10,15 @@ RUN git clone  -b "v4.11.1" --recursive https://github.com/folio-org/okapi.git
 RUN cd okapi && mvn clean install -DskipTests
 
 #OpenJDK Alpine
-FROM alpine:3.15.0
+FROM alpine:3.15.6
 
+#Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Okapi Prerequisites
-RUN apk add --no-cache curl openjdk11
+RUN apk upgrade \
+ && apk add \
+      curl \
+      openjdk11 \
+ && rm -rf /var/cache/apk/*
 
 #Copy in files at this build layer
 RUN mkdir -p /usr/local/bin/folio/

--- a/alternative-install/kubernetes-rancher/TAMU/stripes-tamu/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/stripes-tamu/Dockerfile
@@ -35,6 +35,9 @@ RUN yarn build --okapi $OKAPI_URL --tenant $TENANT_ID ./output
 #Load balancer
 FROM nginx:stable-alpine
 
+#Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade --no-cache
+
 #Expose the Stripes Nginx port
 EXPOSE 3000
 


### PR DESCRIPTION
https://github.com/folio-org/folio-install/tree/master/alternative-install/kubernetes-rancher/TAMU

has several Dockerfiles that have vulnerable packages.

Adding apk upgrade or apt upgrade bumps to the latest patch version and fixes these vulnerabilities:

* zlib/zlib1g, zlib/zlib Out-of-bounds Write Out-of-bounds Write https://nvd.nist.gov/vuln/detail/CVE-2022-37434
* busybox/ssl_client  https://nvd.nist.gov/vuln/detail/CVE-2022-28391
* libretls/libretls, openssl/libssl1.1 Loop with Unreachable Exit Condition ('Infinite Loop') https://nvd.nist.gov/vuln/detail/CVE-2022-0778
* openssl/libssl1.1 Inadequate Encryption Strength https://www.cve.org/CVERecord?id=CVE-2022-2097