### PR TITLE
Upgrade alpine from 3.15 to 3.16

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/bootstrap-superuser/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/bootstrap-superuser/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-email/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-email/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-tenant/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/create-tenant/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/delete-deploy/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/delete-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites

--- a/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/secure-okapi/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/deploy-jobs/secure-okapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Prerequisites

--- a/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/okapi/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone  -b "v4.11.1" --recursive https://github.com/folio-org/okapi.git
 RUN cd okapi && mvn clean install -DskipTests
 
 #OpenJDK Alpine
-FROM alpine:3.15.6
+FROM alpine:3.16
 
 #Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #Okapi Prerequisites


### PR DESCRIPTION
Don't pin the patch version so that the base image contains most security fixes.
This reduces the total download size because `apk upgrade` needs to
install less upgrades.
https://pythonspeed.com/articles/security-updates-in-docker/