### PR TITLE
Add 9 health check endpoints

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/module_metadata.md
+++ b/alternative-install/kubernetes-rancher/TAMU/module_metadata.md
@@ -13,7 +13,7 @@ Startup Options:<br/>
 JAVA_OPTIONS = -XX:MaxRAMPercentage=66.0 -Drequest_timeout_ms=7200000 -Dokapi_url=http://okapi:9130 -Dhttp.port=8081 -Dsecure_store=Ephemeral -Dsecure_store_props=/etc/folio/edge/edge-ephemeral.properties -Dcaia_soft_client=tamu_admin<br/>
 Database connection: No<br/>
 Port: 8081<br/>
-Health Check endpoint: NA<br/>
+Health Check endpoint: /admin/health<br/>
 Volume mounts: /etc/folio/edge
 
 ### edge-connexion
@@ -29,7 +29,7 @@ Startup Options:<br/>
 JAVA_OPTIONS = -XX:MaxRAMPercentage=66.0 -Drequest_timeout_ms=7200000 -Dokapi_url=http://okapi:9130 -Dhttp.port=8081 -Dsecure_store=Ephemeral -Dsecure_store_props=/etc/folio/edge/edge-ephemeral.properties -Dstaging_director_client=tamu_admin<br/>
 Database connection: No<br/>
 Port: 8081<br/>
-Health Check endpoint: NA<br/>
+Health Check endpoint: /admin/health<br/>
 Volume mounts: /etc/folio/edge
 
 ### edge-ncip
@@ -95,14 +95,14 @@ Startup Options:<br/>
 JAVA_OPTIONS = -XX:MaxRAMPercentage=66.0<br/>
 Database connection: Yes<br/>
 Port: 8081<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-authtoken
 Startup Options:<br/>
 JAVA_OPTIONS = -Djwt.signing.key=foo -XX:MaxRAMPercentage=66.0 -Dcache.permissions=true -Dlog.level=warn -Dperm.lookup.timeout=10 -Duser.cache.seconds=60 -Duser.cache.purge.seconds=43200 -Dsys.perm.cache.seconds=259200 -Dport=8081<br/>
 Database connection: No<br/>
 Port: 8081<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-calendar
 Startup Options:<br/>
@@ -184,7 +184,7 @@ KAFKA_PORT = 9092<br/>
 KAFKA_HOST = http://kafka-r2<br/>
 Database connection: Yes<br/>
 Port: 8081<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-data-export-worker
 Startup Options:<br/>
@@ -199,7 +199,7 @@ AWS_SECRET_ACCESS_KEY = key<br/>
 AWS_URL = minio.org<br/>
 Database connection: Yes<br/>
 Port: 8081<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-data-import
 Startup Options:<br/>
@@ -252,7 +252,7 @@ JAVA_OPTIONS = -XX:MaxRAMPercentage=66.0<br/>
 CONFIG = {"okapiUrl": "http://okapi:9130"}<br/>
 Database connection: Yes<br/>
 Port: 8081<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-event-config
 Startup Options:<br/>
@@ -297,14 +297,14 @@ OKAPI_TENANT = diku<br/>
 LOGGING_CATEGORIES = ramlpath<br/>
 Database connection: No<br/>
 Port: 3001<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-inventory
 Startup Options:<br/>
 JAVA_OPTIONS = -XX:MaxRAMPercentage=66.0 -Dorg.folio.metadata.inventory.storage.type=okapi<br/>
 Database connection: No<br/>
 Port: 9403<br/>
-Health Check endpoint: NA
+Health Check endpoint: /admin/health
 
 ### mod-inventory-storage
 Startup Options:<br/>


### PR DESCRIPTION
edge-caiasoft has the health API since version 1.2.0 and it still exists in latest (master). https://github.com/folio-org/edge-caiasoft/blob/v1.2.0/src/main/resources/application.yml#L20-L25

edge-dematic has the health API since version 1.4.0 and it still exists in latest (master). https://github.com/folio-org/edge-dematic/blob/v1.4.0/src/main/resources/application.yml#L21-L26 https://github.com/folio-org/edge-dematic/blob/master/src/main/resources/application.yml#L21-L26

mod-audit has the health API since version 1.0.0 and it still exists in latest (master). https://github.com/folio-org/mod-audit/blob/v1.0.0/mod-audit-server/src/test/java/org/folio/rest/impl/AuditDataImplApiTest.java#L31-L32

mod-authtoken has the health API since version 2.9.0 and it still exists in latest (master). https://github.com/folio-org/mod-authtoken/commit/4b53aa1079c48d58725b3111775d5f0d3073ab42

mod-data-export-spring has the health API since version 1.0.5 and it still exists in latest (master). https://issues.folio.org/browse/MODEXPS-12
https://github.com/folio-org/mod-data-export-spring/blob/v1.0.5/src/main/resources/application.yml#L45-L50 https://github.com/folio-org/mod-data-export-spring/blob/v1.5.3/src/test/java/org/folio/des/InstallUpgradeIT.java#L122-L129

mod-data-export-worker has the health API since version 1.0.7 and it still exists in latest (master). https://issues.folio.org/browse/MODEXPW-9
https://github.com/folio-org/mod-data-export-worker/blob/v1.0.7/src/main/resources/application.properties#L54-L56

mod-erm-usage-harvester has the health API since verision 1.1.0 and it still exists in latest (master). https://github.com/folio-org/mod-erm-usage-harvester/blob/v1.1.0/mod-erm-usage-harvester-core/pom.xml#L16-L19

mod-graphql has the health API since version 1.6.0 and it still exists in latest (master). https://issues.folio.org/browse/MODGQL-133
https://github.com/folio-org/mod-graphql/blob/v1.6.0/src/app.js#L63-L66

mod-inventory has the health API since version 19.0.0 and it still exists in latest (master). https://issues.folio.org/browse/MODINV-749
https://github.com/folio-org/mod-inventory/blob/v19.0.0/src/test/java/it/InventoryIT.java