### PR TITLE
Secure okapi patch

### DIFF
--- a/runbooks/single-server/scripts/secure-supertenant.py
+++ b/runbooks/single-server/scripts/secure-supertenant.py
@@ -10,7 +10,6 @@ import uuid
 
 SUPERUSER_PERMISSIONS = [
     "okapi.all",
-    "okapi.proxy.pull.modules.post",
     "perms.all",
     "login.all",
     "users.all"

--- a/runbooks/single-server/scripts/secure-supertenant.py
+++ b/runbooks/single-server/scripts/secure-supertenant.py
@@ -134,11 +134,12 @@ def fetch_module_ids(module_names, okapi_url):
 
 def enable_module(module_id, okapi_url, tenant=None):
     tenant = tenant or 'supertenant'
-    payload = json.dumps({
-                'id' : module_id
-            }).encode('UTF-8')
+    payload = json.dumps([{
+                'id' : module_id,
+                'action': 'enable'
+            }]).encode('UTF-8')
     return okapi_post(okapi_url +
-                      '/_/proxy/tenants/{}/modules'.format(tenant),
+                      '/_/proxy/tenants/{}/install?deploy=false&preRelease=false&tenantParameters=loadSample%3Dfalse%2CloadReference%3Dfalse'.format(tenant),
                       payload)
 
 def create_user_mod_users(username, okapi_url, id=None, tenant=None):


### PR DESCRIPTION
This patch addresses timeout issues with using `/_/proxy/tenants/{tenant_id}/modules` endpoint to enable modules on okapi v4.14.12. Per the [API docs](https://s3.amazonaws.com/foliodocs/api/okapi/p/okapi.html#proxy_tenants__tenant_id__modules_post), this endpoint  "will eventually be replaced by the 'install' service." By changing the script to use the install service, there are no timeout issues and the script completes successfully.