### PR TITLE
FOLIO-4029 Add depCheck=false parameter for managing mod-authtoken in bootstrap-superuser.pl

### DIFF
--- a/runbooks/single-server/scripts/bootstrap-superuser.pl
+++ b/runbooks/single-server/scripts/bootstrap-superuser.pl
@@ -60,7 +60,7 @@ unless ($only_perms) {
   if ($st_token) {
     push(@{$header},( 'X-Okapi-Token' => $st_token, 'X-Okapi-Tenant' => 'supertenant' ));
   }
-  $req = HTTP::Request->new('POST',"$okapi/_/proxy/tenants/$tenant/install",$header,encode_json([ $authtoken ]));
+  $req = HTTP::Request->new('POST',"$okapi/_/proxy/tenants/$tenant/install?depCheck=false",$header,encode_json([ $authtoken ]));
   $resp = $ua->request($req);
   die $resp->status_line . "\n" unless $resp->is_success;
   my $disabled = decode_json($resp->content);
@@ -144,7 +144,7 @@ unless ($only_perms) {
   if ($st_token) {
     push(@{$header},( 'X-Okapi-Token' => $st_token, 'X-Okapi-Tenant' => 'supertenant' ));
   }
-  $req = HTTP::Request->new('POST',"$okapi/_/proxy/tenants/$tenant/install",$header,encode_json($enable));
+  $req = HTTP::Request->new('POST',"$okapi/_/proxy/tenants/$tenant/install?depCheck=false",$header,encode_json($enable));
   $resp = $ua->request($req);
   die $resp->status_line . "\n" unless $resp->is_success;
   print "OK\n";


### PR DESCRIPTION
With the addition of the Keycloak-enabled modules that implement interfaces also implemented by mod-authtoken and mod-login, the old bootstrap-superuser.pl script has problems if the target Okapi has done a recent pull from the FOLIO module descriptor registry. See [FOLIO-4029|https://folio-org.atlassian.net/browse/FOLIO-4029] for more details.

This problem can be worked around by adding the `depCheck=false` query parameter to calls to the Okapi `/_/proxy/tenant/{tenantId}/install` endpoint with versions of Okapi >= v5.3.0.

So I think it is fair to say that this script now _requires_ Okapi >= v5.3.0