### PR TITLE
FOLIO-4092: Upgrade image of system-prune/Dockerfile

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/system-prune/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/system-prune/Dockerfile
@@ -1,6 +1,11 @@
-FROM docker:24.0.9
-RUN apk update
-RUN apk add bash
+FROM docker:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade \
+ && apk add \
+      bash \
+ && rm -rf /var/cache/apk/*
+
 ENV DELAY_TIME=**None**
 
 ADD run.sh /run.sh


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4092

Upgrade docker:24.0.9 to docker:latest.

Replace “apk update” with “apk upgrade”.

Clean apk cache to reduce image size.

The upgrades will fix these vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2024-45491  expat/libexpat Integer Overflow or Wraparound
* https://nvd.nist.gov/vuln/detail/CVE-2024-45492  expat/libexpat Integer Overflow or Wraparound
* https://nvd.nist.gov/vuln/detail/CVE-2024-45490  expat/libexpat XML External Entity (XXE) Injection
* https://nvd.nist.gov/vuln/detail/CVE-2024-7264  curl/libcurl Out-of-bounds Read

The change will automatically upgrade to latest versions to ensure that all available security fixes get used without any further manual action.