### PR TITLE
Replace debian:buster-slim with alpine:3.21 in ldp-derived-tables/Dockerfile

### DIFF
--- a/alternative-install/kubernetes-rancher/TAMU/ldp-derived-tables/Dockerfile
+++ b/alternative-install/kubernetes-rancher/TAMU/ldp-derived-tables/Dockerfile
@@ -1,8 +1,14 @@
-FROM debian:buster-slim
+FROM alpine:3.21
 
 #Upgrade all packages: https://pythonspeed.com/articles/security-updates-in-docker/
 #LDP Derived Tables Prerequisites
-RUN apt update -y && apt upgrade -y && apt install -y postgresql-client libcurl4-openssl-dev perl libdbi-perl libdbd-pg-perl
+RUN apk upgrade \
+ && apk add \
+      perl \
+      perl-dbd-pg \
+      perl-dbi \
+      postgresql-client \
+ && rm -rf /var/cache/apk/*
 
 #Create folders in container
 RUN mkdir -p /usr/local/bin/ldp/sql/derived_tables


### PR DESCRIPTION
debian:buster-slim (Debian 10) is no longer supported by the Debian maintainers, security updates have been discontinued as of June 30th, 2022.

It has many known security vulnerabilities: https://snyk.io/test/docker/debian:buster-slim

Upgrade to alpine:3.21.